### PR TITLE
update ProjectMMO compat

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -109,8 +109,8 @@ dependencies {
     compileOnly fg.deobf("curse.maven:the-one-probe-245211:3965693")
 //    runtimeOnly fg.deobf("curse.maven:the-one-probe-245211:3965693")
 
-    compileOnly fg.deobf("curse.maven:project-mmo-353935:4119696") // https://github.com/Harmonised7/project_mmo
-//    runtimeOnly fg.deobf("curse.maven:project-mmo-353935:4119696")
+    compileOnly fg.deobf("curse.maven:project-mmo-353935:4357711") // https://github.com/Caltinor/Project-MMO-2.0
+    runtimeOnly fg.deobf("curse.maven:project-mmo-353935:4357711")
 
     compileOnly fg.deobf("curse.maven:carry-on-274259:4160388")
 //    runtimeOnly fg.deobf("curse.maven:carry-on-274259:4160388")

--- a/forge/src/main/java/ht/treechop/compat/ProjectMMO.java
+++ b/forge/src/main/java/ht/treechop/compat/ProjectMMO.java
@@ -2,27 +2,13 @@ package ht.treechop.compat;
 
 import harmonised.pmmo.api.APIUtils;
 import harmonised.pmmo.api.enums.EventType;
-import harmonised.pmmo.core.Core;
-import harmonised.pmmo.events.impl.BreakHandler;
-import harmonised.pmmo.storage.ChunkDataHandler;
-import harmonised.pmmo.storage.ChunkDataProvider;
-import harmonised.pmmo.storage.IChunkData;
+import harmonised.pmmo.api.enums.ObjectType;
 import ht.treechop.TreeChop;
-import ht.treechop.api.ChopEvent;
 import ht.treechop.common.block.ChoppedLogBlock;
-import ht.treechop.common.config.ConfigHandler;
-import ht.treechop.common.registry.ForgeModBlocks;
-import net.minecraft.core.BlockPos;
+import ht.treechop.common.block.ChoppedLogBlock.MyEntity;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModList;
@@ -30,77 +16,40 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
 @EventBusSubscriber(modid = TreeChop.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public class ProjectMMO {
 
     @SubscribeEvent
     public static void commonSetup(FMLCommonSetupEvent event) {
-        if (ConfigHandler.COMMON.compatForProjectMMO.get() && ModList.get().isLoaded("pmmo")) {
-            MinecraftForge.EVENT_BUS.register(EventHandler.class);
+        if (ModList.get().isLoaded("pmmo")) {
+        	//This registers custom configuration behavior for the block which is checked before a standard configuration
+            APIUtils.registerBlockXpGainTooltipData(TreeChop.resource("chopped_log"), EventType.BLOCK_BREAK, TREE_XP);
         }
     }
-
-    private static Map<String, Long> getOverrideXp() {
-        return Collections.singletonMap("woodcutting", ConfigHandler.COMMON.pmmoOverrideXp.get());
-    }
-
-    private static Map<String, Long> getOriginalLogXp(BlockEntity entity) {
-        final ResourceLocation defaultXpKey = ForgeRegistries.BLOCKS.getKey(Blocks.OAK_LOG);
-        Block log = (entity instanceof ChoppedLogBlock.MyEntity choppedEntity) ? choppedEntity.getOriginalState().getBlock() : Blocks.OAK_LOG;
-        ResourceLocation resource = Optional.ofNullable(ForgeRegistries.BLOCKS.getKey(log)).orElse(defaultXpKey);
-
-        double scale = ConfigHandler.COMMON.pmmoScaleXp.get();
-        return Core.get(LogicalSide.SERVER).getXpUtils().getObjectExperienceMap(EventType.BLOCK_BREAK, resource)
-                .entrySet().stream().collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> Math.round(entry.getValue() * scale))
-                );
-    }
-
-    private static class EventHandler {
-        @SubscribeEvent
-        public static void onFinishChop(ChopEvent.FinishChopEvent event) {
-            fixPmmoRegistration();
-
-            clearBlockHistory(event.getPlayer(), event.getLevel(), event.getChoppedBlockPos(), event.getChoppedBlockState());
-
-            BreakHandler.handle(new BlockEvent.BreakEvent(
-                    event.getLevel(),
-                    event.getChoppedBlockPos(),
-                    event.getChoppedBlockState(),
-                    event.getPlayer()
-            ));
-        }
-
-        private static void fixPmmoRegistration() {
-            if (!xpModifierIsRegistered()) {
-                if (ConfigHandler.COMMON.pmmoXpMethod.get() == ProjectMMOChopXp.USE_BLOCK_XP) {
-                    APIUtils.registerBlockXpGainTooltipData(TreeChop.resource("chopped_log"), EventType.BLOCK_BREAK, ProjectMMO::getOriginalLogXp);
-                } else {
-                    Core.get(LogicalSide.SERVER).getXpUtils().setObjectXpGainMap(EventType.BLOCK_BREAK, ForgeModBlocks.CHOPPED_LOG.getId(), getOverrideXp());
-                }
-            }
-        }
-
-        private static boolean xpModifierIsRegistered() {
-            return Core.get(LogicalSide.SERVER).getTooltipRegistry().xpGainTooltipExists(ForgeModBlocks.CHOPPED_LOG.getId(), EventType.BLOCK_BREAK);
-        }
-
-        private static void clearBlockHistory(Player player, Level level, BlockPos pos, BlockState blockState) {
-            try {
-                // Copied from harmonised.pmmo.events.impl::calculateXpAward
-                LevelChunk chunk = (LevelChunk) level.getChunk(pos);
-                IChunkData cap = chunk.getCapability(ChunkDataProvider.CHUNK_CAP).orElseGet(ChunkDataHandler::new);
-                cap.delPos(pos);
-            } catch (NullPointerException e) {
-                TreeChop.LOGGER.warn(String.format("Something went wrong with ProjectMMO compatibility when chopping %s for player %s", blockState, player.toString()));
-            }
-        }
-    }
-
+    
+    /**<p>When invoked, this method confirms the {@link BlockEntity} being supplied is a
+     * treechop {@link ChoppedLogBlock} and obtains the original log type.  The original
+     * type is then used to grab that block's default configuration, which is returned.</p>
+     * <p>This behavior ensures that any configuration tied to the "treechop:chopped_log"
+     * block is ignored in favor of the output of this function.</p> 
+     * 
+     * @return a default configuration setting from the original log block
+     */
+    @SuppressWarnings("resource") //for getLevel call on choppedLog
+	private static final Function<BlockEntity, Map<String, Long>> TREE_XP = (blockEntityIn) -> {
+    	if (blockEntityIn instanceof ChoppedLogBlock.MyEntity) {
+    		ChoppedLogBlock.MyEntity choppedLog = (MyEntity) blockEntityIn;
+    		ResourceLocation resource = Optional
+    				.ofNullable(ForgeRegistries.BLOCKS.getKey(choppedLog.getOriginalState().getBlock()))
+    				.orElse(ForgeRegistries.BLOCKS.getKey(Blocks.OAK_LOG));
+    		
+    		return APIUtils.getXpAwardMap(ObjectType.BLOCK, EventType.BLOCK_BREAK, resource, choppedLog.getLevel().isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER);
+    	}
+    	return new HashMap<>();
+    };
 }

--- a/shared/src/main/java/ht/treechop/common/config/ConfigHandler.java
+++ b/shared/src/main/java/ht/treechop/common/config/ConfigHandler.java
@@ -6,7 +6,6 @@ import ht.treechop.common.config.resource.ResourceIdentifier;
 import ht.treechop.common.platform.ModLoader;
 import ht.treechop.common.settings.*;
 import ht.treechop.common.util.AxeAccessor;
-import ht.treechop.compat.ProjectMMOChopXp;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
@@ -235,10 +234,6 @@ public class ConfigHandler {
         public final ForgeConfigSpec.BooleanValue fakePlayerFellingEnabled;
         public final ForgeConfigSpec.BooleanValue fakePlayerTreesMustHaveLeaves;
         public final InitializedSupplier<Boolean> compatForMushroomStems = defaultValue(true);
-        public final InitializedSupplier<Boolean> compatForProjectMMO = defaultValue(true);
-        public final InitializedSupplier<ProjectMMOChopXp> pmmoXpMethod = defaultValue(ProjectMMOChopXp.USE_BLOCK_XP);
-        public final InitializedSupplier<Double> pmmoScaleXp = defaultValue(1.0);
-        public final InitializedSupplier<Long> pmmoOverrideXp = defaultValue(80L);
         public final InitializedSupplier<Boolean> compatForDynamicTrees = defaultValue(true);
         public final ForgeConfigSpec.BooleanValue verboseAPI;
         protected final List<Pair<Setting, ForgeConfigSpec.BooleanValue>> rawPermissions = new LinkedList<>();
@@ -480,23 +475,6 @@ public class ConfigHandler {
                                 "Prevent conflicts with DynamicTrees",
                                 "See https://www.curseforge.com/minecraft/mc-mods/dynamictrees"))
                         .define("dynamicTrees", true));
-
-                builder.push("projectMMO");
-                compatForProjectMMO.set(builder
-                        .comment(String.join("\n",
-                                "Fix ProjectMMO XP awards for chopping",
-                                "See https://www.curseforge.com/minecraft/mc-mods/project-mmo"))
-                        .define("projectMMO", true));
-                pmmoXpMethod.set(builder
-                        .comment("When chopping, award the default XP for the chopped block or use a custom value")
-                        .defineEnum("useBlockXpOrOverride", ProjectMMOChopXp.USE_BLOCK_XP));
-                pmmoScaleXp.set(builder
-                        .comment(String.format("Multiplier for the amount of XP awarded if useBlockXpOrOverride = %s", ProjectMMOChopXp.USE_BLOCK_XP.name()))
-                        .defineInRange("xpMultiplier", 1.0, 0.0, 100000.0));
-                pmmoOverrideXp.set(builder
-                        .comment(String.format("How much XP to award if useBlockXpOrOverride = %s", ProjectMMOChopXp.OVERRIDE.name()))
-                        .defineInRange("xpOverride", 80L, 0L, 100000L));
-                builder.pop();
             }
 
             builder.push("API");

--- a/shared/src/main/java/ht/treechop/compat/ProjectMMOChopXp.java
+++ b/shared/src/main/java/ht/treechop/compat/ProjectMMOChopXp.java
@@ -1,6 +1,0 @@
-package ht.treechop.compat;
-
-public enum ProjectMMOChopXp {
-    USE_BLOCK_XP,
-    OVERRIDE
-}


### PR DESCRIPTION
Hello,

It was brought to my attention by a few users that compat with PMMO was broken by one of my recent updates to PMMO.  The cause of this crash was Treechop using internal methods instead of API methods.  Upon review of the treechop compat class, it appears my API was lacking in a way that forced you to use these methods.  As such, I added methods to Project MMO's API to remedy this deficit.  

This PR takes advantage of this new API hook while also updating the compat logic to better align with the API design philosophy of Project MMO.  

## Summary of Changes
In your original implementation, you managed log variation by updating the internal configurations prior to executing the break so that the current log break instance received the correct log as the root of its settings immediately before each break action.  while this was effective, it was circumventing existing behavior which handled these scenarios.

the method `APIUtils.registerBlockXpGainTooltipData` works by using the function parameter to calculate the xp map when an xp event occurs.  Since PMMO listens to events on lowest priority, this means that your `ChopEvent` logic already handles the prevention of premature XP by cancelling the break event until the finish chop case is reached.  When a block is actually broken and the Forge break event fires, pmmo will use this registered function to calculate the XP using the original log.  The newly added API hook makes this possible by allowing you to query the configuration for the original log.

On the topic of original log xp, this implementation defers configuration to the standard configuration of blocks in PMMO.  This means that the xp modification configurations in your Config are no longer needed.  Pmmo already provides a means for players to modify the XP amounts, so the feature was delegated back to pmmo to reduce your compat overhead.

Lastly, you were diligent in clearing the block cache, which I appreciate.  However, since treechop replaces the blocks with air and a player cannot break air, there is no scenario where leftover values would be used.  That code was stripped out for parsimony.

## Conclusion
This implementation relies exclusively on API hooks, making your compat more stable over time.  Configuration settings of treechop were delegated back to existing settings in PMMO.  

Please let me know if you have any questions or concerns.  If you are satisfied with this, I can also submit a PR to backport this behavior to 1.18.2